### PR TITLE
Add options to ignore missing date and check real attachment size

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ The script in this repository contains a few additional features which I found u
 ## Usage
 
 ```
-./maildir2gmail.py [-f] [-n] -u <username> -p <password> <maildirs>
+./maildir2gmail.py [-f] [-n] [--ignore-missing-date] [--max-size=MAX_SIZE] -u <username> -p <password> <maildirs>
 ```
 
 By default, all mails are uploaded to _All Mail_ in Gmail, following the Google concept of "never delete mails, just archive everything".
 A folder can be specified using the _-f_ option. Non-existent folders will be created automatically.
 
-Mails can be marked as Unseen (new) using the _n_ option.
+Mails can be marked as Unseen (new) using the _-n_ option.
+
+Use option _--ignore-missing-date_ to ignore all messages with missing date. In this case, messages are imported to gmail with the creation date of the file.
+
+You can set the maximum size for messages with the option _--max-size=MAX_SIZE_ (in bytes). Messages that are larger than the defined size are skipped. Default is 25 MB (Gmail limitation for IMAP).
 
 Username and Password are required, IMAP for your mailbox must be turned on (do this in the Settings for your mailbox). In addition you have to allow [_less secure apps_](https://support.google.com/accounts/answer/6010255) in your Gmail interface.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A folder can be specified using the _-f_ option. Non-existent folders will be cr
 
 Mails can be marked as Unseen (new) using the _-n_ option.
 
-Use option _--ignore-missing-date_ to ignore all messages with missing date. In this case, messages are imported to gmail with the creation date of the file.
+Use option _--ignore-missing-date_ to ignore all messages with missing date. In this case, messages are imported to gmail with the last modification time of the file.
 
 You can set the maximum size for messages with the option _--max-size=MAX_SIZE_ (in bytes). Messages that are larger than the defined size are skipped. Default is 25 MB (Gmail limitation for IMAP).
 

--- a/maildir2gmail.py
+++ b/maildir2gmail.py
@@ -60,7 +60,7 @@ class Gmail(object):
         message = email.message_from_string(content)
         timestamp = parsedate(message['date'])
         fileTimestamp = os.path.getctime(filename)
-	if not self.ignore_missing_date:
+        if not self.ignore_missing_date:
             if not timestamp:
                 log('Skipping "%s" - no date (creation time of file: %s)' % (os.path.basename(filename), datetime.datetime.fromtimestamp(fileTimestamp).strftime('%Y-%m-%d %H:%M:%S')))
                 return

--- a/maildir2gmail.py
+++ b/maildir2gmail.py
@@ -2,13 +2,14 @@
 
 """Upload email messages from a list of Maildir to Google Mail."""
 
-__version__ = '0.3'
+__version__ = '0.4'
 
 import email
 import email.Header
 import email.Utils
 import os
 import sys
+import datetime
 import time
 import re
 from pprint import pprint
@@ -20,6 +21,8 @@ class Gmail(object):
         self.password = options.password
         self.new_flag = options.new_flag
         self.folder = options.folder
+        self.ignore_missing_date = options.ignore_missing_date
+        self.max_size = options.max_size
         if self.folder == 'inbox':
             self.folder = 'INBOX'
         else:
@@ -56,12 +59,29 @@ class Gmail(object):
 
         message = email.message_from_string(content)
         timestamp = parsedate(message['date'])
-        if not timestamp:
-            log('Skipping "%s" - no date' % os.path.basename(filename))
+        fileTimestamp = os.path.getctime(filename)
+	if not self.ignore_missing_date:
+            if not timestamp:
+                log('Skipping "%s" - no date (creation time of file: %s)' % (os.path.basename(filename), datetime.datetime.fromtimestamp(fileTimestamp).strftime('%Y-%m-%d %H:%M:%S')))
+                return
+        else:
+            timestamp = os.path.getctime(filename)
+
+        if message.is_multipart():
+            message_size = 0
+            for part in message.walk():
+                part_payload = part.get_payload(decode=True)
+                if part_payload:
+                    message_size = message_size + len(part_payload)
+        else:
+            message_size = len(content)
+
+        subject = decode_header(message['subject'])        
+        if message_size > self.max_size:
+            log('Skipping "%s" (subject: "%s") - message too large (max. 25 MB); Size was %d bytes)' % (os.path.basename(filename), subject, len(content)))
             return
 
-        subject = decode_header(message['subject'])
-        log('Sending "%s" (%d bytes)' % (subject, len(content)))
+        log('Sending "%s" (%d bytes)' % (subject, message_size))
         del message
 
         if self.new_flag:
@@ -167,6 +187,10 @@ def main():
         help='Username to log into Gmail')
     parser.add_option('-n', '--new', dest='new_flag', action = 'store_true',
         help='Flag all messages as UNSEEN')
+    parser.add_option('--ignore-missing-date', dest='ignore_missing_date', action='store_true',
+        help='Ignores messages with missing date and sets the file creation time instead')
+    parser.add_option('--max-size', dest='max_size', type="int", default=25000000,
+        help='Defines maximum message size [default: %default bytes]')
 
     options, args = parser.parse_args()
 


### PR DESCRIPTION
I've added a new option _--ignore-missing-date_. If set and a message has no date, the date of the file is used.

I also added a option _--max-size=MAX_SIZE_ (in bytes) to define the max allowed size for messages. If the message is a multipart message, the decoded size of parts (attachments) will be calculated. If the message is larger than the defined size, the message is skipped. Previously, the execution of the script is cancelled caused by an exception.