### PR TITLE
Recommend app password

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The script in this repository contains a few additional features which I found u
 ## Usage
 
 ```
-./maildir2gmail.py [-f] [-n] [--ignore-missing-date] [--max-size=MAX_SIZE] -u <username> -p <password> <maildirs>
+./maildir2gmail.py [-f] [-n] [--ignore-missing-date] [--max-size=MAX_SIZE] -u <username> -p <app-password> <maildirs>
 ```
 
 By default, all mails are uploaded to _All Mail_ in Gmail, following the Google concept of "never delete mails, just archive everything".
@@ -25,4 +25,4 @@ Use option _--ignore-missing-date_ to ignore all messages with missing date. In 
 
 You can set the maximum size for messages with the option _--max-size=MAX_SIZE_ (in bytes). Messages that are larger than the defined size are skipped. Default is 25 MB (Gmail limitation for IMAP).
 
-Username and Password are required, IMAP for your mailbox must be turned on (do this in the Settings for your mailbox). In addition you have to allow [_less secure apps_](https://support.google.com/accounts/answer/6010255) in your Gmail interface.
+Username and Password are required, IMAP for your mailbox must be turned on (do this in the Settings for your mailbox). In addition you have to create an [app password](https://support.google.com/accounts/answer/185833).


### PR DESCRIPTION
Less secure app is not an option when 2fa is enabled for your account. The only solution is app passwords.

App passwords is the recommended method anyway.