### PR TITLE
Use shelve instead of dbhash

### DIFF
--- a/maildir2gmail.py
+++ b/maildir2gmail.py
@@ -98,10 +98,10 @@ class Gmail(object):
 
     @property
     def database(self):
-        import dbhash
         if self.__database is None:
-            dbname = os.path.abspath(os.path.splitext(sys.argv[0])[0] + '.db')
-            self.__database = dbhash.open(dbname, 'w')
+            import shelve
+            dbname = os.path.abspath(os.path.splitext(sys.argv[0])[0])
+            self.__database = shelve.open(dbname)
         return self.__database
 
     @property


### PR DESCRIPTION
dbhash is not loadable on Mac OS X because of a missing BSD database
library (bsddb.)

Fortunately, shelve works, and since this is just a dictionary that is
persisted to disk, it's perfect for this use case.

Note: shelve already appends '.db' to the end of the filename, so remove
it from our script.